### PR TITLE
Added NullPointerException on the 'throws' of updateStory method

### DIFF
--- a/socialauth-android/src/org/brickred/socialauth/android/SocialAuthAdapter.java
+++ b/socialauth-android/src/org/brickred/socialauth/android/SocialAuthAdapter.java
@@ -894,7 +894,7 @@ public class SocialAuthAdapter {
 	@SuppressWarnings("unchecked")
 	public void updateStory(final String message, final String name, final String caption, final String description,
 			final String link, final String picture, final SocialAuthListener<Integer> listener)
-			throws UnsupportedEncodingException {
+			throws UnsupportedEncodingException,NullPointerException {
 
 		if (getCurrentProvider().getProviderId().equalsIgnoreCase("facebook")) {
 			final Map<String, String> params = new HashMap<String, String>();


### PR DESCRIPTION
The getCurrentProvider() sometimes returns 'null' and using that in the condition of the if statement inside 'updateStory' would result an uncaught NullPointerException. 
